### PR TITLE
Sort pieces in hand when exporting SFEN

### DIFF
--- a/shogi/__init__.py
+++ b/shogi/__init__.py
@@ -1108,7 +1108,7 @@ class Board(object):
         for color in COLORS:
             p = self.pieces_in_hand[color]
             pih_len += len(p)
-            for piece_type in p.keys():
+            for piece_type in sorted(p.keys(), reverse=True):
                 if p[piece_type] >= 1:
                     if p[piece_type] > 1:
                         sfen.append(str(p[piece_type]))


### PR DESCRIPTION
SFEN出力時の手駒の順番を強い駒のから降順にソートするようにしました

参考:
- http://yaneuraou.yaneu.com/2016/07/15/sfen%E6%96%87%E5%AD%97%E5%88%97%E3%81%AF%E4%B8%80%E6%84%8F%E3%81%AB%E5%AE%9A%E3%81%BE%E3%82%89%E3%81%AA%E3%81%84%E4%BB%B6/

- https://web.archive.org/web/20080131070731/http://www.glaurungchess.com/shogi/usi.html