### PR TITLE
Fix issue 9: Null move の bool判定がTrueになる

### DIFF
--- a/shogi/Move.py
+++ b/shogi/Move.py
@@ -119,4 +119,4 @@ class Move(object):
         >>> bool(shogi.Move.null())
         False
         '''
-        return cls(0, 0, NONE)
+        return cls(None, None, NONE)

--- a/tests/move_test.py
+++ b/tests/move_test.py
@@ -27,10 +27,10 @@ class MoveTestCase(unittest.TestCase):
         self.assertEqual(move.__hash__(), 9)
 
     def test_issue_9(self):
-	self.assertEqual(bool(shogi.Move.null()), False)
-	board = shogi.Board()
-	board.push(shogi.Move.null())
-	self.assertEqual(board.captured_piece_stack[0], 0)
+        self.assertEqual(bool(shogi.Move.null()), False)
+        board = shogi.Board()
+        board.push(shogi.Move.null())
+        self.assertEqual(board.captured_piece_stack[0], 0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/move_test.py
+++ b/tests/move_test.py
@@ -26,5 +26,11 @@ class MoveTestCase(unittest.TestCase):
         move = shogi.Move.from_usi('9a9b')
         self.assertEqual(move.__hash__(), 9)
 
+    def test_issue_9(self):
+	self.assertEqual(bool(shogi.Move.null()), False)
+	board = shogi.Board()
+	board.push(shogi.Move.null())
+	self.assertEqual(board.captured_piece_stack[0], 0)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix issue https://github.com/gunyarakun/python-shogi/issues/9,
it was indeed causing a possible push to captured_piece_stack of a piece code.

Added a test with two assertions.