### PR TITLE
Add time control to summary of CSA

### DIFF
--- a/shogi/CSA.py
+++ b/shogi/CSA.py
@@ -472,6 +472,7 @@ class TCPProtocol:
             'names': names,
             'sfen': sfen,
             'moves': [],
+            'time': time_summary,
         }
 
         return {

--- a/tests/csa_test.py
+++ b/tests/csa_test.py
@@ -73,7 +73,8 @@ class ParserTest(unittest.TestCase):
 TEST_SUMMARY = {
     'names': ['kiki_no_onaka_black', 'kiki_no_omata_white'],
     'sfen': 'lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1',
-    'moves': []
+    'moves': [],
+    'time': {'Time_Unit': '1sec', 'Total_Time': '900', 'Byoyomi': '0', 'Least_Time_Per_Move': '1'}
 }
 
 TEST_SUMMARY_STR = '''BEGIN Game_Summary


### PR DESCRIPTION
CSA Protocolで対局開始時に、持ち時間の設定を取得したい時があるので、
wait_match() でその情報を取れるようにしてみました。