### PR TITLE
Feature: Allow for custom starting boards through kif files (Issue #24)

### DIFF
--- a/shogi/KIF.py
+++ b/shogi/KIF.py
@@ -223,10 +223,27 @@ class Parser:
         for line in kif_str.split('\n'):
             if len(line) == 0 or line[0] == "*":
                 pass
+<<<<<<< HEAD
             elif '：' in line:
                 (key, value) = line.split('：', 1)
                 value = value.rstrip('　')
                 if key == '先手' or key == '下手': # sente or shitate
+=======
+            elif line.count('+') == 2 and line.count('-') > 10:
+                if custom_sfen:
+                    custom_sfen = False
+                    # remove last slash
+                    sfen = sfen[:-1]
+                else:
+                    custom_sfen = True
+                    sfen = ''
+            elif custom_sfen:
+                sfen = ''.join((sfen, Parser.parse_board_line(line), '/'))
+            elif '\uff1a' in line:
+                (key, value) = line.split('\uff1a', 1)
+                value = value.rstrip('\u3000')
+                if key == '\u5148\u624b' or key == '\u4e0b\u624b': # sente or shitate
+>>>>>>> change: changed the way to detect the custom board
                     # Blacks's name
                     names[shogi.BLACK] = value
                 elif key == '後手' or key == '上手': # gote or uwate

--- a/shogi/KIF.py
+++ b/shogi/KIF.py
@@ -87,7 +87,6 @@ class Parser:
         line_sfen = ''
         square_skip = 0
         sente = True
-        print(board_line)
 
         for square in board_line:
             # if there is a piece in the square (no dot)
@@ -123,11 +122,20 @@ class Parser:
     @staticmethod
     def parse_move_str(line, last_to_square):
         # Normalize king/promoted kanji
+<<<<<<< HEAD
         line = line.replace('王', '玉')
         line = line.replace('竜', '龍')
         line = line.replace('成銀', '全')
         line = line.replace('成桂', '圭')
         line = line.replace('成香', '杏')
+=======
+        line = line.replace('\u738b', '\u7389')
+        line = line.replace('\u7adc', '\u9f8d')
+        line = line.replace('\u6210\u9280', '\u5168')
+        line = line.replace('\u6210\u6842', '\u572d')
+        line = line.replace('\u6210\u9999', '\u674f')
+        line = line.replace('+', '')
+>>>>>>> fixed: problems with kif importer when multiple move branches exist
 
         m = Parser.MOVE_RE.match(line)
         if m:
@@ -193,10 +201,27 @@ class Parser:
         for line in kif_str.split('\n'):
             if len(line) == 0 or line[0] == "*":
                 pass
+<<<<<<< HEAD
             elif '：' in line:
                 (key, value) = line.split('：', 1)
                 value = value.rstrip('　')
                 if key == '先手' or key == '下手': # sente or shitate
+=======
+            elif line == '+---------------------------+':
+                if custom_sfen:
+                    custom_sfen = False
+                    # remove last forward slash
+                    sfen = sfen[:-1]
+                else:
+                    custom_sfen = True
+                    sfen = ''
+            elif custom_sfen:
+                sfen = ''.join((sfen, Parser.parse_board_line(line), '/'))
+            elif '\uff1a' in line:
+                (key, value) = line.split('\uff1a', 1)
+                value = value.rstrip('\u3000')
+                if key == '\u5148\u624b' or key == '\u4e0b\u624b': # sente or shitate
+>>>>>>> fixed: problems with kif importer when multiple move branches exist
                     # Blacks's name
                     names[shogi.BLACK] = value
                 elif key == '後手' or key == '上手': # gote or uwate
@@ -214,7 +239,13 @@ class Parser:
                     sfen = Parser.HANDYCAP_SFENS[value]
                     if sfen is None:
                         raise ParserException('Cannot support handycap type "other"')
+<<<<<<< HEAD
             elif line == '後手番':
+=======
+                elif key == '\u5909\u5316':  # henka
+                    break  # TODO: add alternative move suggestions / branches
+            elif line == '\u5f8c\u624b\u756a':
+>>>>>>> fixed: problems with kif importer when multiple move branches exist
                 # Current turn is white
                 current_turn = shogi.WHITE
             else:
@@ -250,7 +281,6 @@ class Parser:
                             win = '-'
             line_no += 1
 
-        print(sfen)
         summary = {
             'names': names,
             'sfen': sfen,

--- a/tests/kif_test.py
+++ b/tests/kif_test.py
@@ -475,26 +475,26 @@ TEST_KIF_81DOJO_RESULT = {
     'win': 'b',
 }
 TEST_KIF_CUSTOM_BOARD_RESULT = {'names': ['大内延介', '最新詰将棋２００選'],
-                                'sfen': '8l/4R+B2k/7p1/6s2/9/9/9/9/9 b 1r1b4g3s4n3l17p 1',
+                                'sfen': '8l/4R+B2k/7p1/6s2/9/9/9/9/9 w 1r1b4g3s4n3l17p 1',
                                 'moves': ['4b3a'],
                                 'win': '-'}
 
 
 
 class ParserTest(unittest.TestCase):
-    def parse_str_test(self):
+    def test_parse_str(self):
         result = KIF.Parser.parse_str(TEST_KIF_STR)
         self.assertEqual(result[0], TEST_KIF_RESULT)
 
-    def parse_str_with_time_test(self):
+    def test_parse_str_with_time(self):
         result = KIF.Parser.parse_str(TEST_KIF_STR_WITH_TIME)
         self.assertEqual(result[0], TEST_KIF_WITH_TIME_RESULT)
 
-    def parse_str_81dojo_test(self):
+    def test_str_81dojo(self):
         result = KIF.Parser.parse_str(TEST_KIF_81DOJO)
         self.assertEqual(result[0], TEST_KIF_81DOJO_RESULT)
 
-    def parse_file_test(self):
+    def test_parse_file(self):
         try:
             tempdir = tempfile.mkdtemp()
 

--- a/tests/kif_test.py
+++ b/tests/kif_test.py
@@ -358,6 +358,35 @@ TEST_KIF_81DOJO = """#KIF version=2.0 encoding=UTF-8\r
 12   投了   (0:5/0:0:22)\r
 """
 
+TEST_KIF_CUSTOM_BOARD = """# ----  Kifu for Windows V4.01β 棋譜ファイル  ----
+# ファイル名：D:\\b\\temp\\M2TOK141\\KIFU\\1t120600-1.kif
+棋戦：１手詰
+戦型：なし
+手合割：平手　　
+後手の持駒：飛　角　金四　銀三　桂四　香三　歩十七　
+  ９ ８ ７ ６ ５ ４ ３ ２ １
++---------------------------+
+| ・ ・ ・ ・ ・ ・ ・ ・v香|一
+| ・ ・ ・ ・ 飛 馬 ・ ・v玉|二
+| ・ ・ ・ ・ ・ ・ ・v歩 ・|三
+| ・ ・ ・ ・ ・ ・v銀 ・ ・|四
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|五
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|六
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|七
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|八
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|九
++---------------------------+
+先手の持駒：なし
+先手：大内延介
+後手：最新詰将棋２００選
+手数----指手---------消費時間--
+*作者：大内延介
+*発表誌：最新詰将棋２００選
+   1 ３一馬(42)   ( 0:00/00:00:00)
+   2 中断         ( 0:00/00:00:00)
+まで1手で中断
+"""
+
 TEST_KIF_RESULT = {
     'moves': [
         '7g7f', '3c3d', '2g2f', '4c4d', '3i4h', '8b4b', '5i6h', '5a6b', '6h7h',
@@ -411,6 +440,11 @@ TEST_KIF_81DOJO_RESULT = {
     'names': ['KikiNoOmata', 'XiaoNoOmata'],
     'win': 'b',
 }
+TEST_KIF_CUSTOM_BOARD_RESULT = {'names': ['大内延介', '最新詰将棋２００選'],
+                                'sfen': '8l/4R+B2k/7p1/6s2/9/9/9/9/9 b 1r1b4g3s4n3l17p 1',
+                                'moves': ['4b3a'],
+                                'win': '-'}
+
 
 class ParserTest(unittest.TestCase):
     def parse_str_test(self):
@@ -450,5 +484,13 @@ class ParserTest(unittest.TestCase):
                 f.write(TEST_KIF_STR)
             result = KIF.Parser.parse_file(path)
             self.assertEqual(result[0], TEST_KIF_RESULT)
+
+            # .kif with custom starting position
+            path = os.path.join(tempdir, 'test_tsume.kif')
+            with codecs.open(path, 'w', 'cp932') as f:
+                f.write(TEST_KIF_CUSTOM_BOARD)
+            result = KIF.Parser.parse_file(path)
+            self.assertEqual(result[0], TEST_KIF_CUSTOM_BOARD_RESULT)
+
         finally:
             shutil.rmtree(tempdir)


### PR DESCRIPTION
## Feature description 
Addition to the kif parser that imports the custom starting board as sfen (perfect for tsume problems) as discussed in issue #24 .
- finds the board in the kif file
- creates a sfen from the information given
- updates the sfen string with the given board state
- added TODO note for extra move branches (変化)
- added extra unit test for tsume problem

## Need help with some information:
as of right now, i have that the custom sfen uses the current_turn variable as whos turn it is and just the number 1 as turn number. Is this the correct way of doing it? In other words, what should the turn variable and the move variable be for the sfen? Either:
1. turn = 'b', move = 1 to signify the start of the game
2. turn = current_turn, move = len(moves) to signify where the game will be after using all the moves

Thanks in advance! 