### PR TITLE
Feature: Allow for custom starting boards through kif files (Issue #24) - fix

### DIFF
--- a/shogi/KIF.py
+++ b/shogi/KIF.py
@@ -290,7 +290,6 @@ class Parser:
 
         # if using a custom sfen
         if len(sfen.split(' ')) == 1:
-            print(pieces_in_hand)
             sfen = Parser.complete_custom_sfen(sfen, pieces_in_hand, current_turn)
 
         summary = {

--- a/tests/kif_test.py
+++ b/tests/kif_test.py
@@ -358,6 +358,36 @@ TEST_KIF_81DOJO = """#KIF version=2.0 encoding=UTF-8\r
 12   投了   (0:5/0:0:22)\r
 """
 
+
+TEST_KIF_CUSTOM_BOARD = """# ----  Kifu for Windows V4.01β 棋譜ファイル  ----
+# ファイル名：D:\\b\\temp\\M2TOK141\\KIFU\\1t120600-1.kif
+棋戦：１手詰
+戦型：なし
+手合割：平手　　
+後手の持駒：飛　角　金四　銀三　桂四　香三　歩十七　
+  ９ ８ ７ ６ ５ ４ ３ ２ １
++---------------------------+
+| ・ ・ ・ ・ ・ ・ ・ ・v香|一
+| ・ ・ ・ ・ 飛 馬 ・ ・v玉|二
+| ・ ・ ・ ・ ・ ・ ・v歩 ・|三
+| ・ ・ ・ ・ ・ ・v銀 ・ ・|四
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|五
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|六
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|七
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|八
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|九
++---------------------------+
+先手の持駒：なし
+先手：大内延介
+後手：最新詰将棋２００選
+手数----指手---------消費時間--
+*作者：大内延介
+*発表誌：最新詰将棋２００選
+   1 ３一馬(42)   ( 0:00/00:00:00)
+   2 中断         ( 0:00/00:00:00)
+まで1手で中断
+"""
+
 TEST_KIF_RESULT = {
     'moves': [
         '7g7f', '3c3d', '2g2f', '4c4d', '3i4h', '8b4b', '5i6h', '5a6b', '6h7h',
@@ -412,6 +442,11 @@ TEST_KIF_81DOJO_RESULT = {
     'win': 'b',
 }
 
+TEST_KIF_CUSTOM_BOARD_RESULT = {'names': ['大内延介', '最新詰将棋２００選'],
+                                'sfen': '8l/4R+B2k/7p1/6s2/9/9/9/9/9 w 1r1b4g3s4n3l17p 1',
+                                'moves': ['4b3a'],
+                                'win': '-'}
+
 class ParserTest(unittest.TestCase):
     def test_parse_str(self):
         result = KIF.Parser.parse_str(TEST_KIF_STR)
@@ -423,7 +458,6 @@ class ParserTest(unittest.TestCase):
 
     def test_parse_str_81dojo(self):
         result = KIF.Parser.parse_str(TEST_KIF_81DOJO)
-        print(result[0])
         self.assertEqual(result[0], TEST_KIF_81DOJO_RESULT)
 
     def test_parse_file(self):
@@ -450,5 +484,13 @@ class ParserTest(unittest.TestCase):
                 f.write(TEST_KIF_STR)
             result = KIF.Parser.parse_file(path)
             self.assertEqual(result[0], TEST_KIF_RESULT)
+
+            # .kif with custom starting position
+            path = os.path.join(tempdir, 'test_tsume.kif')
+            with codecs.open(path, 'w', 'cp932') as f:
+                f.write(TEST_KIF_CUSTOM_BOARD)
+            result = KIF.Parser.parse_file(path)
+            self.assertEqual(result[0], TEST_KIF_CUSTOM_BOARD_RESULT)
+
         finally:
             shutil.rmtree(tempdir)

--- a/tests/kif_test.py
+++ b/tests/kif_test.py
@@ -413,20 +413,20 @@ TEST_KIF_81DOJO_RESULT = {
 }
 
 class ParserTest(unittest.TestCase):
-    def parse_str_test(self):
+    def test_parse_str(self):
         result = KIF.Parser.parse_str(TEST_KIF_STR)
         self.assertEqual(result[0], TEST_KIF_RESULT)
 
-    def parse_str_with_time_test(self):
+    def test_parse_str_with_time(self):
         result = KIF.Parser.parse_str(TEST_KIF_STR_WITH_TIME)
         self.assertEqual(result[0], TEST_KIF_WITH_TIME_RESULT)
 
-    def parse_str_81dojo_test(self):
+    def test_parse_str_81dojo(self):
         result = KIF.Parser.parse_str(TEST_KIF_81DOJO)
         print(result[0])
         self.assertEqual(result[0], TEST_KIF_81DOJO_RESULT)
 
-    def parse_file_test(self):
+    def test_parse_file(self):
         try:
             tempdir = tempfile.mkdtemp()
 


### PR DESCRIPTION
### this is the same as the previous pull request, but from a better starting position. I hope this will resolve any conflicts smoothly. 

## Feature description 
Addition to the kif parser that imports the custom starting board as sfen (perfect for tsume problems) as discussed in issue #24 .
- finds the board in the kif file
- creates a sfen from the information given
- updates the sfen string with the given board state
- added TODO note for extra move branches (変化)
- added extra unit test for tsume problem

## Need help with some information:
as of right now, i have that the custom sfen uses the current_turn variable as whos turn it is and just the number 1 as turn number. Is this the correct way of doing it? In other words, what should the turn variable and the move variable be for the sfen? Either:
1. turn = 'b', move = 1 to signify the start of the game
2. turn = current_turn, move = len(moves) to signify where the game will be after using all the moves

Thanks in advance! 