### PR TITLE
function to read position cmd in USI protocol

### DIFF
--- a/shogi/__init__.py
+++ b/shogi/__init__.py
@@ -971,6 +971,34 @@ class Board(object):
             return False
         return self.piece_bb[PAWN] & self.occupied[self.turn] & BB_FILES[file_index(to_square)]
 
+    def push_usi_position_cmd(self, usi_position_cmd):
+        '''
+        Updates the position from position command in USI protocol.
+        
+        Example:
+        >>> board.push_usi_position_cmd("position startpos moves 7g7f 3c3d")
+        '''
+        if usi_position_cmd.startswith("position startpos") or usi_position_cmd.startswith("position sfen"):
+            sfen_id = usi_position_cmd.find("sfen")
+            moves_id = usi_position_cmd.find("moves")
+        else:
+            raise ValueError("Invalid command {0} position cmd in USI protocol must starts from 'position startpos' or 'position sfen'".format(repr(usi_position_cmd)))
+    
+        if sfen_id != -1:
+            if moves_id != -1:
+                sfen = usi_position_cmd[sfen_id+5:moves_id]
+            else:
+                sfen = usi_position_cmd[sfen_id+5:]
+            self.set_sfen(sfen)
+        else:
+            self.reset()
+
+        if moves_id != -1:
+            moves = usi_position_cmd[moves_id+6:].split(" ")
+            for move in moves:
+                if move != "":
+                    self.push_usi(move)
+    
     def push(self, move):
         '''
         Updates the position with the given move and puts it onto a stack.

--- a/tests/board_test.py
+++ b/tests/board_test.py
@@ -203,5 +203,19 @@ class BoardTestCase(unittest.TestCase):
         move = shogi.Move.from_usi('2g5d+')
         self.assertTrue(move in board.legal_moves)
 
+    def test_usi_command(self):
+        board = shogi.Board()
+        
+        board.push_usi_position_cmd("position startpos moves 7g7f")
+        self.assertEqual(board.sfen(), 'lnsgkgsnl/1r5b1/ppppppppp/9/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL w - 2')
+        board.push_usi_position_cmd("position sfen ln1g3+Rl/1ks4s1/pp1gppbpp/2p3N2/9/5P1P1/PPPP1S1bP/2K1R1G2/LNSG3NL w 4p 42")
+        move = shogi.Move.from_usi('2g5d+')
+        self.assertTrue(move in board.legal_moves)
+        board.push_usi_position_cmd("position sfen ln1g3+Rl/1ks4s1/pp1gppbpp/2p3N2/9/5P1P1/PPPP1S1bP/2K1R1G2/LNSG3NL w 4p 42 moves 2g5d+")
+        self.assertEqual(board.sfen(), "ln1g3+Rl/1ks4s1/pp1gppbpp/2p1+b1N2/9/5P1P1/PPPP1S2P/2K1R1G2/LNSG3NL b 4p 43")
+
+        with self.assertRaises(ValueError):
+            board.push_usi_position_cmd("position moves")
+        
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I attached a function to read `position` cmd in USI protocol in `shogi.Board` class.

## example

````
import shogi
board = board.Board()
board.push_usi_position_cmd("position startpos moves 7g7f")
board.sfen()
>>> 'lnsgkgsnl/1r5b1/ppppppppp/9/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL w - 2'
````