### PR TITLE
Extend codec support for CSA file parsing

### DIFF
--- a/shogi/CSA.py
+++ b/shogi/CSA.py
@@ -24,6 +24,7 @@ import shogi
 import socket
 import threading
 import collections
+import codecs
 
 DEFAULT_PORT = 4081
 PING_SLEEP_DURATION = 1
@@ -63,8 +64,13 @@ SERVER_MESSAGES = [
 class Parser:
     @staticmethod
     def parse_file(path):
-        with open(path) as f:
-            return Parser.parse_str(f.read())
+        for enc in ['cp932', 'utf-8-sig']:
+            try:
+                with codecs.open(path, 'r', enc) as f:
+                    return Parser.parse_str(f.read())
+            except:
+                pass
+        return None
 
     @staticmethod
     def parse_str(csa_str):


### PR DESCRIPTION
## Issue

When trying to parse CSA file in a Windows environment, the below error appeared due to not specifying the encoding format. 

```
UnicodeDecodeError: 'cp932' codec can't decode byte 0x86 in position 47: illegal multibyte sequence
```

## Solution

This fix will specify the two encoding formats already used to parse a KIF file which are 'cp932' and 'utf-8-sig'.