### PR TITLE
PV, value and comment parser in CSA

### DIFF
--- a/shogi/__init__.py
+++ b/shogi/__init__.py
@@ -971,6 +971,34 @@ class Board(object):
             return False
         return self.piece_bb[PAWN] & self.occupied[self.turn] & BB_FILES[file_index(to_square)]
 
+    def push_usi_position_cmd(self, usi_position_cmd):
+        '''
+        Updates the position from position command in USI protocol.
+        
+        Example:
+        >>> board.push_usi_position_cmd("position startpos moves 7g7f 3c3d")
+        '''
+        if usi_position_cmd.startswith("position startpos") or usi_position_cmd.startswith("position sfen"):
+            sfen_id = usi_position_cmd.find("sfen")
+            moves_id = usi_position_cmd.find("moves")
+        else:
+            raise ValueError("Invalid command {0} position cmd in USI protocol must starts from 'position startpos' or 'position sfen'".format(repr(usi_position_cmd)))
+    
+        if sfen_id != -1:
+            if moves_id != -1:
+                sfen = usi_position_cmd[sfen_id+5:moves_id]
+            else:
+                sfen = usi_position_cmd[sfen_id+5:]
+            self.set_sfen(sfen)
+        else:
+            self.reset()
+
+        if moves_id != -1:
+            moves = usi_position_cmd[moves_id+6:].split(" ")
+            for move in moves:
+                if move != "":
+                    self.push_usi(move)
+    
     def push(self, move):
         '''
         Updates the position with the given move and puts it onto a stack.

--- a/tests/board_test.py
+++ b/tests/board_test.py
@@ -203,5 +203,19 @@ class BoardTestCase(unittest.TestCase):
         move = shogi.Move.from_usi('2g5d+')
         self.assertTrue(move in board.legal_moves)
 
+    def test_usi_command(self):
+        board = shogi.Board()
+        
+        board.push_usi_position_cmd("position startpos moves 7g7f")
+        self.assertEqual(board.sfen(), 'lnsgkgsnl/1r5b1/ppppppppp/9/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL w - 2')
+        board.push_usi_position_cmd("position sfen ln1g3+Rl/1ks4s1/pp1gppbpp/2p3N2/9/5P1P1/PPPP1S1bP/2K1R1G2/LNSG3NL w 4p 42")
+        move = shogi.Move.from_usi('2g5d+')
+        self.assertTrue(move in board.legal_moves)
+        board.push_usi_position_cmd("position sfen ln1g3+Rl/1ks4s1/pp1gppbpp/2p3N2/9/5P1P1/PPPP1S1bP/2K1R1G2/LNSG3NL w 4p 42 moves 2g5d+")
+        self.assertEqual(board.sfen(), "ln1g3+Rl/1ks4s1/pp1gppbpp/2p1+b1N2/9/5P1P1/PPPP1S2P/2K1R1G2/LNSG3NL b 4p 43")
+
+        with self.assertRaises(ValueError):
+            board.push_usi_position_cmd("position moves")
+        
 if __name__ == '__main__':
     unittest.main()

--- a/tests/csa_test.py
+++ b/tests/csa_test.py
@@ -56,15 +56,18 @@ P9+KY+KE+GI+KI+OU+KI+GI+KE+KY
 +
 '指し手と消費時間(optional)
 +2726FU
+'** 22 -8384FU
 T12
 -3334FU
 T6
+'** 0 +2625FU -8384FU +6978KI -8485FU +3938GI -7172GI +9796FU
 +7776FU
+'using csa format is a kind of torment!
 %TORYO
 '---------------------------------------------------------
 """
 
-TEST_CSA_SUMMARY = {'moves': ['2g2f', '3c3d', '7g7f'], 'sfen': 'lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1', 'names': ['NAKAHARA', 'YONENAGA'], 'win': 'b'}
+TEST_CSA_SUMMARY = {'moves': ['2g2f', '3c3d', '7g7f'], 'sfen': 'lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1', 'names': ['NAKAHARA', 'YONENAGA'], 'win': 'b', 'values': [[22], [0], []], 'comments' : ['', '', ["'using csa format is a kind of torment!"]], 'pvs': [[['8c8d']], [['2f2e', '8c8d', '6i7h', '8d8e', '3i3h', '7a7b', '9g9f']], []], 'comments': [[], [], ["'using csa format is a kind of torment!"]]}
 
 TEST_CSA_WITH_PI = '''
 V2.2
@@ -85,15 +88,19 @@ TEST_CSA_SUMMARY_WITH_PI = {
     'moves': ['7g7f', '8c8d'],
     'sfen': 'lnsgkgsnl/9/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1',
     'names': ['先手', '後手'],
-    'win': 'w'
+    'win': 'w',
+    'comments' : [[],[]],
+    'pvs' : [[], []],
+    'values' : [[], []],
 }
 
 class ParserTest(unittest.TestCase):
-    def parse_str_test(self):
+    def test_parse_str_test(self):
         result = CSA.Parser.parse_str(TEST_CSA)
+        print(result[0])
         self.assertEqual(result[0], TEST_CSA_SUMMARY)
 
-    def parse_str_test_with_PI(self):
+    def test_parse_str_test_with_PI(self):
         result = CSA.Parser.parse_str(TEST_CSA_WITH_PI)
         self.assertEqual(result[0], TEST_CSA_SUMMARY_WITH_PI)
 


### PR DESCRIPTION
I attached a comment, pv and value parser in CSA. It would be useful for the analysis of the playout in floodgate. Example of io is shown below

input
```
'バージョン                                                                                                                                                  
V2.2                                                                                                                                                         
'対局者名                                                                                                                                                    
N+NAKAHARA                                                                                                                                                   
N-YONENAGA                                                                                                                                                   
'棋譜情報                                                                                                                                                    
'棋戦名                                                                                                                                                      
$EVENT:13th World Computer Shogi Championship                                                                                                                
'対局場所                                                                                                                                                    
$SITE:KAZUSA ARC                                                                                                                                             
'開始日時                                                                                                                                                    
$START_TIME:2003/05/03 10:30:00                                                                                                                              
'終了日時                                                                                                                                                    
$END_TIME:2003/05/03 11:11:05                                                                                                                                
'持ち時間:25分、切れ負け                                                                                                                                     
$TIME_LIMIT:00:25+00                                                                                                                                         
'戦型:矢倉                                                                                                                                                   
$OPENING:YAGURA                                                                                                                                              
'平手の局面                                                                                                                                                  
P1-KY-KE-GI-KI-OU-KI-GI-KE-KY                                                                                                                                
P2 * -HI *  *  *  *  * -KA *                                                                                                                                 
P3-FU-FU-FU-FU-FU-FU-FU-FU-FU                                                                                                                                
P4 *  *  *  *  *  *  *  *  *                                                                                                                                 
P5 *  *  *  *  *  *  *  *  *                                                                                                                                 
P6 *  *  *  *  *  *  *  *  *                                                                                                                                 
P7+FU+FU+FU+FU+FU+FU+FU+FU+FU                                                                                                                                
P8 * +KA *  *  *  *  * +HI *                                                                                                                                 
P9+KY+KE+GI+KI+OU+KI+GI+KE+KY                                                                                                                                
'先手番                                                                                                                                                      
+                                                                                                                                                            
'指し手と消費時間(optional)                                                                                                                             
+2726FU                                                                                                                                                      
'** 22 -8384FU                                                                                                                                               
T12                                                                                                                                                          
-3334FU                                                                                                                                                      
T6                                                                                                                                                           
'** 0 +2625FU -8384FU +6978KI -8485FU +3938GI -7172GI +9796FU                                                                                                
+7776FU                                                                                                                                                      
'using csa format is a kind of torment!                                                                                                                      
%TORYO                                                                                                                                                       
```

output

`{'moves': ['2g2f', '3c3d', '7g7f'], 'sfen': 'lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1', 'names': ['NAKAHARA', 'YONENAGA'], 'win': 'b', 'values': [[22], [0], []], 'comments' : ['', '', ["'using csa format is a kind of torment!"]], 'pvs': [[['8c8d']], [['2f2e', '8c8d', '6i7h', '8d8e', '3i3h', '7a7b', '9g9f']], []], 'comments': [[], [], ["'using csa format is a kind of torment!"]]}
`

# Discussion
As far as I know, CSA format does not provide strict rules to determine which comments contain PV and values. This PR supports CSA files generated by floodgate. Comment parser in this PR would raise error when comment format is different from floodgate's format. Therefore, it is preferable to skip the comment parser when it raises errors.

This parser tries to support MultiPV and multiline comments to gather the information by list. However, floodgate does not support MultiPV and multiline comments. 