### PR TITLE
Enable KIF parser to split pieces_in_hands with " "

### DIFF
--- a/shogi/KIF.py
+++ b/shogi/KIF.py
@@ -79,7 +79,7 @@ class Parser:
             return ordered_dict()
 
         result = ordered_dict()
-        for item in target.split("　"):
+        for item in target.replace(" ", "　").split("　"):
             if len(item) == 1:
                 result[shogi.PIECE_JAPANESE_SYMBOLS.index(item)] = 1
             elif len(item) == 2 or len(item) == 3:

--- a/tests/kif_test.py
+++ b/tests/kif_test.py
@@ -384,6 +384,31 @@ TEST_KIF_CUSTOM_BOARD = """# ----  Kifu for Windows V4.01β 棋譜ファイル  
 まで1手で中断
 """
 
+TEST_KIF_CUSTOM_BOARD_SHOGI_GUI = """#KIF version=2.0 encoding=UTF-8
+開始日時：2024/02/06 17:26:03
+後手の持駒：飛 角 金四 銀三 桂四 香三 歩十七
+  ９ ８ ７ ６ ５ ４ ３ ２ １
++---------------------------+
+| ・ ・ ・ ・ ・ ・ ・ ・v香|一
+| ・ ・ ・ ・ 飛 馬 ・ ・v玉|二
+| ・ ・ ・ ・ ・ ・ ・v歩 ・|三
+| ・ ・ ・ ・ ・ ・v銀 ・ ・|四
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|五
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|六
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|七
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|八
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|九
++---------------------------+
+先手の持駒：なし
+先手：大内延介
+後手：最新詰将棋２００選
+手数----指手---------消費時間--
+   1 ３一馬(42)        ( 0:00/00:00:00)
+   2 中断             ( 0:00/00:00:00)
+まで1手で中断
+"""
+
+
 TEST_KIF_EXPORTED_TO_KIF = """開始日時： \r
 終了日時： \r
 手合割：平手\r
@@ -904,11 +929,12 @@ class ParserTest(unittest.TestCase):
             self.assertEqual(result[0], TEST_KIF_RESULT)
 
             # .kif with custom starting position
-            path = os.path.join(tempdir, "test_tsume.kif")
-            with codecs.open(path, "w", "cp932") as f:
-                f.write(TEST_KIF_CUSTOM_BOARD)
-            result = KIF.Parser.parse_file(path)
-            self.assertEqual(result[0], TEST_KIF_CUSTOM_BOARD_RESULT)
+            for test_str in [TEST_KIF_CUSTOM_BOARD, TEST_KIF_CUSTOM_BOARD_SHOGI_GUI]:
+                path = os.path.join(tempdir, "test_tsume.kif")
+                with codecs.open(path, "w", "cp932") as f:
+                    f.write(test_str)
+                result = KIF.Parser.parse_file(path)
+                self.assertEqual(result[0], TEST_KIF_CUSTOM_BOARD_RESULT)
 
         finally:
             shutil.rmtree(tempdir)


### PR DESCRIPTION
I found KIF parsing issue generated by ShogiGUI.
In KIF generated by ShogiGUI, pieces in hands (which occured in edited starting board) are splitted with space character " ".
I am not sure what is correct KIF specification, but I would like to allow pytho-shogi to parse such KIF files.

What this PR does is:

- Append normalization process from " " to "　".
- Append a testcase with " "

Could you check it? Thanks.